### PR TITLE
fix VariableNode constant entity bug

### DIFF
--- a/net/loveruby/cflat/ast/VariableNode.java
+++ b/net/loveruby/cflat/ast/VariableNode.java
@@ -37,6 +37,24 @@ public class VariableNode extends LHSNode {
         entity = ent;
     }
 
+    /*==============================================
+    =            fix constant entity bug            =
+    ==============================================*/
+    public boolean isLvalue() { 
+        if (entity.isConstant()) {
+            return false;
+        }
+        return true; 
+    }
+
+    public boolean isAssignable() { 
+        if (entity.isConstant()) {
+            return false;
+        }
+        return isLoadable(); 
+    }
+    /*=====  End of fix constant entity bug  ======*/
+    
     public TypeNode typeNode() {
         return entity().typeNode();
     }


### PR DESCRIPTION
修改了VariableNode 的entity为constant情况下的bug。
详情见issue：
https://github.com/leungwensen/cbc-ubuntu-64bit/issues/1
