### PR TITLE
fix forNode bug

### DIFF
--- a/net/loveruby/cflat/ast/ForNode.java
+++ b/net/loveruby/cflat/ast/ForNode.java
@@ -1,4 +1,5 @@
 package net.loveruby.cflat.ast;
+import net.loveruby.cflat.type.*;
 
 public class ForNode extends StmtNode {
     protected StmtNode init;
@@ -9,9 +10,21 @@ public class ForNode extends StmtNode {
     public ForNode(Location loc, 
                    ExprNode init, ExprNode cond, ExprNode incr, StmtNode body) {
         super(loc);
-        this.init = new ExprStmtNode(init.location(), init);
-        this.cond = cond;
-        this.incr = new ExprStmtNode(incr.location(), incr);
+        if (init != null) {
+            this.init = new ExprStmtNode(init.location(), init);
+        } else {
+            this.init = null;
+        }
+        if (cond != null) {
+            this.cond = cond;
+        } else {
+            this.cond = new IntegerLiteralNode(null, IntegerTypeRef.intRef(), 1);
+        }
+        if (incr != null) {
+            this.incr = new ExprStmtNode(incr.location(), incr);
+        } else {
+            this.incr = null;
+        }
         this.body = body;
     }
 

--- a/net/loveruby/cflat/compiler/IRGenerator.java
+++ b/net/loveruby/cflat/compiler/IRGenerator.java
@@ -297,8 +297,7 @@ class IRGenerator implements ASTVisitor<Void, Expr> {
         Label bodyLabel = new Label();
         Label contLabel = new Label();
         Label endLabel = new Label();
-
-        transformStmt(node.init());
+        if (node.init() != null) transformStmt(node.init());
         label(begLabel);
         cjump(node.location(),
                 transformExpr(node.cond()), bodyLabel, endLabel);
@@ -309,7 +308,7 @@ class IRGenerator implements ASTVisitor<Void, Expr> {
         popBreak();
         popContinue();
         label(contLabel);
-        transformStmt(node.incr());
+        if (node.incr() != null) transformStmt(node.incr());
         jump(begLabel);
         label(endLabel);
         return null;

--- a/net/loveruby/cflat/compiler/Visitor.java
+++ b/net/loveruby/cflat/compiler/Visitor.java
@@ -81,9 +81,9 @@ abstract public class Visitor implements ASTVisitor<Void, Void> {
     }
 
     public Void visit(ForNode n) {
-        visitStmt(n.init());
-        visitExpr(n.cond());
-        visitStmt(n.incr());
+        if (n.init() != null) visitStmt(n.init());
+        if (n.cond() != null) visitExpr(n.cond());
+        if (n.incr() != null) visitStmt(n.incr());
         visitStmt(n.body());
         return null;
     }


### PR DESCRIPTION
修复for循环的bug。
修改前的for循环init，cond，incr均不能为空，这显然有问题。
修改后的for循环可以省略init，cond，incr任意项，如：for( ; ; )
